### PR TITLE
fix statscreen helpbox issue

### DIFF
--- a/Wizardry/Core/StatScreen/MiscFix/HelpBoxFix.c
+++ b/Wizardry/Core/StatScreen/MiscFix/HelpBoxFix.c
@@ -1,0 +1,14 @@
+#include "common-chax.h"
+
+/* Reset helpbox when switching unit */
+
+/* LynJump */
+void StartGlowBlendCtrl(void)
+{
+#if CHAX
+    sLastHbi = NULL;
+    gStatScreen.help = NULL;
+#endif
+
+    Proc_Start(gProcScr_SSGlowyBlendCtrl, PROC_TREE_3);
+}

--- a/Wizardry/Core/StatScreen/StatScreen.event
+++ b/Wizardry/Core/StatScreen/StatScreen.event
@@ -13,6 +13,9 @@
 
 #include "DrawMorePage/DrawMorePage.event"
 
+#include "MiscFix/HelpBoxFix.lyn.event"
+#include "MiscFix/LynJump.event"
+
 ALIGN 4
 gStatScreenDrawPages:
     POIN 0x08087185


### PR DESCRIPTION
when switching unit, the new unit may have less skills than old unit.

But the helpbox info is saved in `sLastHbi`, which may cause bug if press R_BUTTON.