### PR TITLE
Spellchecking

### DIFF
--- a/Contants/Texts/Source/texts/Skills_AI.txt
+++ b/Contants/Texts/Source/texts/Skills_AI.txt
@@ -14,6 +14,6 @@ likely to target this unit.[X]
 Teleport[X]
 
 ## MSG_SKILL_Teleportation
-Teleportation: Allows to[NL]
-teleport to anywhere and[NL]
+Teleportation: Allows unit[NL]
+to teleport anywhere and[NL]
 take another action.[X]

--- a/Contants/Texts/Source/texts/Skills_BattleAct.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleAct.txt
@@ -1,42 +1,42 @@
 ## MSG_SKILL_Aegis
 Aegis:[NL]
 Nullify a magic attack.[NL]
-(Skill % activation)[X]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Pavise
 Pavise:[NL]
 Nullify a physical attack.[NL]
-(Skill % activation)[X]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Mercy
 Mercy: Leave the opponent at[NL]
 1 HP if the attack would kill.[NL]
-(Skill % activation)[X]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Bane
 Bane:[NL]
-Leave the opponent at 1Hp[NL]
-(Skill % activation)[X]
+Leave the opponent at 1 HP[NL]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Aether
-Aether:Negate 80 %[NL]
+Aether: Negate 80% of enemy[NL]
 defenses and absorb HP.[NL]
-(Skill/2 % activation)[X]
+(Skill/2 % activation).[X]
 
 ## MSG_SKILL_Corona
 Corona:[NL]
 Negate enemy resistance.[NL]
-(Skill% activation)[X]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Luna
 Luna:[NL]
-Negates enemy defenses.[NL]
-(Skill % activation)[X]
+Negates enemy defense.[NL]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Flare
 Flare:[NL]
 Halve enemy resistance.[NL]
-(Skill% activation)[X]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Foresight
 Foresight: Avoid the damage[NL]
@@ -46,32 +46,32 @@ Skill Activations.[X]
 ## MSG_SKILL_Sol
 Sol:[NL]
 Restore damage dealt as HP.[NL]
-(Skill % activation)[X]
+(Skill % activation).[X]
 
 ## MSG_SKILL_DragonFang
 DragonFang:[NL]
-damage +50%.[NL]
-(Skill% activation)[X]
+Damage +50%.[NL]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Colossus
 Colossus:[NL]
-damage +200%.[NL]
-(Skill% activation).[X]
+Damage +200%.[NL]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Impale
 Impale:[NL]
-damage +300%.[NL]
-(Skill% activation).[X]
+Damage +300%.[NL]
+(Skill % activation).[X]
 
 ## MSG_SKILL_Inori
 Inori:[NL]
 Unit may not die if attacked[NL]
-to 0 HP (luck%)[X]
+to 0 HP (Luck % activation).[X]
 
 ## MSG_SKILL_Corrosion
 Corrosion:[NL]
 Reduce enemy's weapon durability[NL]
-by user's level (Skill %).[X]
+by user's level (Skill % activation).[X]
 
 ## MSG_SKILL_Ignis
 Ignis:[NL]
@@ -81,12 +81,12 @@ on weapon type (Skill % activation).[X]
 ## MSG_SKILL_RightfulKing
 RightfulKing:[NL]
 Add +10% to the activation[NL]
-rate of the unit's skills.[X]
+rate of this unit's skills.[X]
 
 ## MSG_SKILL_RightfulGod
 RightfulGod:[NL]
 Add +30% to the activation[NL]
-rate of the unit's skills.[X]
+rate of this unit's skills.[X]
 
 ## MSG_SKILL_RightfulArch
 RightfulArch:[NL]
@@ -95,8 +95,8 @@ this unit's skills to 100%.[X]
 
 ## MSG_SKILL_Glacies
 Glacies:[NL]
-Add unit resistance to damage[NL]
-dealt. (Skill % activation).[X]
+Add unit resistance to damage dealt.[NL] 
+(Skill % activation).[X]
 
 ## MSG_SKILL_GreatShield
 GreatShield:[NL]
@@ -105,7 +105,7 @@ Nullify all attacks.[NL]
 
 ## MSG_SKILL_Vengeance
 Vengeance:[NL]
-Add damage taken to attacl.[NL]
+Add damage taken to attack.[NL]
 (Skill % activation).[X]
 
 ## MSG_SKILL_Deadeye
@@ -115,23 +115,23 @@ Doubles hit rate and inflict sleep.[NL]
 
 ## MSG_SKILL_AxeFaith
 AxeFaith:[NL]
-When attack with Axe, hit + attack%.[NL]
+When attacking with an Axe, hit + attack%.[NL]
 (attack % activation).[X]
 
 ## MSG_SKILL_Armsthrift
 Armsthrift:[NL]
-weapon no consumed[NL]
+A weapon use is not consumed.[NL]
 (Skill % activation).[X]
 
 ## MSG_SKILL_SureShot
 SureShot:[NL]
 100% hit rate, damage +50%.[NL]
- (Skill % activation).[X]
+(Skill % activation).[X]
 
 ## MSG_SKILL_DivinePulse_NAME
 D-Pulse[X]
 
 ## MSG_SKILL_DivinePulse
-Divine Pulse: May turn[NL]
-a missed attack into a hit. Trigger[NL]
-%=30. Chance increases with high Lck.[X]
+Divine Pulse:
+May turn a missed attack into a hit.[NL]
+(30% + Skill % activation rate).[X]

--- a/Contants/Texts/Source/texts/Skills_BattleOrder.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleOrder.txt
@@ -1,25 +1,25 @@
 ## MSG_SKILL_Vantage
 Vantage:[NL]
-When unit is defender with[NL]
-HP is <50%, attack first[X]
+When unit is defender while[NL]
+their HP is < 50%, attack first.[X]
 
 ## MSG_SKILL_Desperation
 Desper: When unit[NL]
-attacks with HP <50%,[NL]
-double attacks immediately[X]
+attacks while their HP < 50%,[NL]
+double attack immediately.[X]
 
 ## MSA_SKILL_QuickRiposte_NAME
 Quick-R[X]
 
 ## MSG_SKILL_QuickRiposte
-Quick Riposte: [NL]
-If unit is attacked with HP[NL]
->50%, double attacks[X]
+Quick Riposte:[NL]
+If unit is attacked while their[NL]
+HP > 50%, they attack twice.[X]
 
 ## MSG_SKILL_WaryFighter
 W-Fighter:[NL]
 Prevents follow up attack[NL]
-if unit's HP >50%[X]
+if unit's HP > 50%.[X]
 
 ## MSG_SKILL_DoubleLion_NAME
 D-Lion[X]
@@ -27,13 +27,14 @@ D-Lion[X]
 ## MSG_SKILL_DoubleLion
 Double Lion:[NL]
 If unit attacks with full HP,[NL]
-enjoys Brave effect and lose 1 HP[X]
+bestow Brave effect and lose 1 HP.[X]
 
 ## MSG_SKILL_Astra
 Astra:[NL]
-Battle +4 hit but damage is halved[NL]
-(spd%)[X]
+Unit attacks 5 times but damage[NL]
+is halved. (SPD % activation).[X]
 
 ## MSG_SKILL_Adept
 Adept:[NL]
-Battle +1 hit if full HP[X]
+Allow unit to perform another[NL]
+attack if HP is full.[X]

--- a/Contants/Texts/Source/texts/Skills_BattleStatus.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleStatus.txt
@@ -1,113 +1,113 @@
 ## MSG_SKILL_Lethality
 Lethality: [NL]
-Unit may casue Lethality in[NL]
-critical attack, Skl%[X]
+Unit may instantly kill enemy with a[NL]
+critical attack. (Skill % activation).[X]
 
 ## MSG_SKILL_Crit
 Crit: [NL]
-Crit rate +15%[X]
+Crit rate +15%.[X]
 
 ## MSG_SKILL_WatchfulEye
 W-Eye: [NL]
-Hit rate +20%[X]
+Hit rate +20%.[X]
 
 ## MSG_SKILL_CritSword
 Crit Sword: [NL]
 Crit rate +10%,[NL]
-if equipped sword[X]
+if a Sword is equipped.[X]
 
 ## MSG_SKILL_CritAxe
 Crit Axe: [NL]
 Crit rate +10%,[NL]
-if equipped axe[X]
+if an Axe is equipped.[X]
 
 ## MSG_SKILL_CritLance
 Crit Lance: [NL]
 Crit rate +10%,[NL]
-if equipped lance[X]
+if a Lance is equipped.[X]
 
 ## MSG_SKILL_CritBow
 Crit Bow: [NL]
 Crit rate +10%,[NL]
-if equipped bow[X]
+if a Bow is equipped.[X]
 
 ## MSG_SKILL_FaireSword
 Faire Sword: [NL]
 Atk +5 if unit[NL]
-equips sword[X]
+equips a Sword.[X]
 
 ## MSG_SKILL_FaireLance
 Faire Lance: [NL]
 Atk +5 if unit[NL]
-equips Lance[X]
+equips a Lance.[X]
 
 ## MSG_SKILL_FaireAxe
 Faire Axe: [NL]
 Atk +5 if unit[NL]
-equips Axe[X]
+equips an Axe.[X]
 
 ## MSG_SKILL_FaireBow
 Faire Bow: [NL]
 Atk +5 if unit[NL]
-equips Bow[X]
+equips a Bow.[X]
 
 ## MSG_SKILL_FaireBMag
 Faire B.Mag: [NL]
 Atk +5 if unit[NL]
-equips B.Mag[X]
+equips B.Mag.[X]
 
 ## MSG_SKILL_Avoid
 Avoid+10:[NL]
-Avoid rate +10%[X]
+Avoid rate +10%.[X]
 
 ## MSG_SKILL_AvoidSword
 Avoid Sword: [NL]
 Grants avoid rate +20%[NL]
-if unit equips sword[X]
+if unit equips a Sword.[X]
 
 ## MSG_SKILL_RuinedBlade
 Ruined Blade: [NL]
-Str/Mag-5, Spd+5, casue[NL]
-5 real damge in combat[X]
+Str/Mag-5, Spd+5, increases[NL]
+real damage by 5 in combat.[X]
 
 ## MSG_SKILL_RuinedBladePlus
 Ruined Blade+:[NL]
 Spd +5, deal real damage +5,[NL]
-battle hit +1 but cannot crit[X]
+battle hit +1 but cannot crit.[X]
 
 ## MSG_SKILL_InfinityEdge
 Infinity Edge: [NL]
-Critical attack deal 400% damage[X]
+Critical attacks deal 400% damage.[X]
 
 ## MSG_SKILL_HeavyBlade
 Heavy Blade: [NL]
 If unit's attack is higher than[NL]
-foe, critical rate +15%[X]
+foe, critical rate +15%.[X]
 
 ## MSG_SKILL_FlashingBlade
 Flashing Blade: [NL]
 If unit's AS is higher than[NL]
-foe, critical rate +15% [X]
+foe, critical rate +15%.[X]
 
 ## MSG_SKILL_HeavyBladePlus
 Heavy Blade+: [NL]
 Str+5. If unit's attack is higher[NL]
-than foe, critical rate +25%[X]
+than foe, critical rate +25%.[X]
 
 ## MSG_SKILL_FlashingBladePlus
 Flash Blade+: [NL]
 Dmg+3. If unit's AS is higher[NL]
-than foe, critical rate +25%[X]
+than foe, critical rate +25%.[X]
 
 ## MSG_SKILL_LunaAttack
 Luna Attack: [NL]
 Grants real dmg bonus[NL]
-as foe's Def x25%[X]
+of enemy's DEF / 4.[X]
 
 ## MSG_SKILL_SorceryBlade
 Sorcery Blade: [NL]
 Target defense is calculated as[NL]
-lower value of Def or Res[X]
+lower value of DEF or RES.[X]
 
 ## MSG_SKILL_Fortune
 Fortune:[NL]
@@ -142,11 +142,11 @@ on the opponent.[X]
 ## MSG_SKILL_Merciless
 Merciless: [NL]
 Guaranteed critical hit[NL]
-against poisoined foes.[X]
+against poisoned foes.[X]
 
 ## MSG_SKILL_CriticalPierce
 CriticalPierce: [NL]
-Neglect opponent's dodge rate.[X]
+Ignore enemy's dodge rate.[X]
 
 ## MSG_SKILL_KillingMachine_NAME
 K-Machine[X]
@@ -175,7 +175,7 @@ holding an E-ranked weapon,[NL]
 boost weapon damage by 50%.[X]
 
 ## MSG_SKILL_CatchingUp
-CatchingUp: If foe doubles unit[NL]
+CatchingUp: If foe doubles unit,[NL]
 increase their attack by the amount[NL]
 they're above the doubling threshold.[X]
 
@@ -200,12 +200,12 @@ enemy, boost damage by the difference.[X]
 ## MSG_SKILL_Chivalry
 Chivalry:[NL]
 When foe is at full HP,[NL]
-attack and def/res +2.[X]
+attack and DEF/RES +2.[X]
 
 ## MSG_SKILL_Pragmatic
 Pragmatic:[NL]
 When foe is not at full HP,[NL]
-attack +3 and def/res+1.[X]
+attack +3 and DEF/RES+1.[X]
 
 ## MSG_SKILL_WindDisciple
 WindDisciple:[NL]
@@ -222,7 +222,7 @@ Crit-Force[X]
 
 ## MSG_SKILL_CriticalForce
 Critical Force:[NL]
-Base critical is Skl * 1.5.[X]
+Base critical is SKL * 1.5.[X]
 
 ## MSG_SKILL_StrongRiposte_NAME
 S-Riposte[X]
@@ -260,22 +260,22 @@ if the opponent can double.[X]
 
 ## MSG_SKILL_FireBoost
 Fire Boost:[NL]
-Grants +6 atk if unit's current HP[NL]
+Grants +6 ATK if unit's current HP[NL]
 is at least 3 higher than the enemy's.[X]
 
 ## MSG_SKILL_WindBoost
 Wind Boost:[NL]
-Grants +6 atk/spd if unit's current HP[NL]
+Grants +6 ATK/SPD if unit's current HP[NL]
 is at least 3 higher than the enemy's.[X]
 
 ## MSG_SKILL_EarthBoost
 Earth Boost:[NL]
-Grants +6 def if unit's current HP[NL]
+Grants +6 DEF if unit's current HP[NL]
 is at least 3 higher than the enemy's.[X]
 
 ## MSG_SKILL_WaterBoost
 Water Boost:[NL]
-Grants +6 res if unit's current HP[NL]
+Grants +6 RES if unit's current HP[NL]
 is at least 3 higher than the enemy's.[X]
 
 ## MSG_SKILL_Charge
@@ -303,7 +303,7 @@ Quick Draw:[NL]
 ## MSG_SKILL_ArcaneBlade
 Arcane Blade:[NL]
 When initiating battle at 1 range:[NL]
-Add 3+(Mag/2) to Hit and Crit[X]
+Add 3+(MAG/2) to Hit and Crit[X]
 
 ## MSG_SKILL_ElbowRoom
 Elbow Room:[NL]
@@ -325,18 +325,18 @@ against a magical foe, or vice versa.[X]
 ## MSG_SKILL_Wrath
 Wrath:[NL]
 If current HP is < 50%[NL]
-of max, +20 crit rate.[X]
+of max, +20 Crit Rate.[X]
 
 ## MSG_SKILL_Vigilance
 Vigilance:[NL]
-Gain +20 avoid.[X]
+Gain +20 Avoid.[X]
 
 ## MSG_SKILL_OutdoorFighter_NAME
 Out-Fighter[X]
 
 ## MSG_SKILL_OutdoorFighter
 OutdoorFighter:[NL]
-+10 hit and avoid when[NL]
++10 Hit and Avoid when[NL]
 fighting outdoors.[X]
 
 ## MSG_SKILL_DancingBlade_NAME
@@ -345,7 +345,7 @@ Dan-Blade:[X]
 ## MSG_SKILL_DancingBlade
 Dancing Blade:[NL]
 +4 Attack Speed/-2 Damage when[NL]
-unit's Con. is lower than the enemy.[X]
+unit's CON. is lower than the enemy.[X]
 
 ## MSG_SKILL_KnightAspirant_NAME
 K-Aspirant[X]
@@ -362,12 +362,12 @@ Outrider:[NL]
 
 ## MSG_SKILL_EvenRhythm
 EvenRhythm:[NL]
-+10 hit and avoid on[NL]
++10 Hit and Avoid on[NL]
 even numbered turns.[X]
 
 ## MSG_SKILL_OddRhythm
 OddRhythm:[NL]
-+10 hit and avoid on[NL]
++10 Hit and Avoid on[NL]
 odd numbered turns.[X]
 
 ## MSG_SKILL_NoGuard
@@ -377,13 +377,13 @@ Both sides have a[NL]
 
 ## MSG_SKILL_Puissance
 Puissance:[NL]
-+3 attack if the user's attacker[NL]
-is greater than the enem's.[X]
++3 Attack if the unit's attack[NL]
+is greater than the enemy's.[X]
 
 ## MSG_SKILL_Prescience
 Prescience:[NL]
 If initiating at melee range,[NL]
-+15 hit and avoid.[X]
++15 Hit and Avoid.[X]
 
 ## MSG_SKILL_SilentPride
 SilentPride:[NL]
@@ -392,35 +392,35 @@ Gain +2 damage and take[NL]
 
 ## MSG_SKILL_Guts
 Guts:[NL]
-+5 attack if afflicted by[NL]
++5 Attack if afflicted by[NL]
 any status condition.[X]
 
 ## MSG_SKILL_Hero
 Hero:[NL]
-If unit HP < 50%, add +30% to[NL]
+If unit's HP < 50%, add +30% to[NL]
 unit's activation skill rate.[X]
 
 ## MSG_SKILL_HolyAura
 Holy Aura:[NL]
-Gain +1 damage, +5% hit,[NL]
-+5% avoid, +5% crit when using light.[X]
+Gain +1 damage, +5% Hit,[NL]
++5% Avoid, +5% Crit when using Light.[X]
 
 ## MSG_SKILL_Loyalty
 Loyalty:[NL]
 When within 2 spaces of a Lord,[NL]
--3 damage taken, +15% hit.[X]
+-3 damage taken, +15% Hit.[X]
 
 ## MSG_SKILL_TowerShield
 Tower Shield:[NL]
-Gain 6 defense against[NL]
-attacks recieved at range.[X]
+Gain 6 Defense against[NL]
+attacks received at range.[X]
 
 ## MSG_SKILL_StunningSmile_NAME
 Stun-Smile[X]
 
 ## MSG_SKILL_StunningSmile
 Stunning Smile:[NL]
-If foe is male, inflicts Avo-20[NL]
+If foe is male, inflicts -20 Avoid[NL]
 on that foe during combat.[X]
 
 ## MSG_SKILL_Trample
@@ -433,11 +433,11 @@ Opportunist:[NL]
 
 ## MSG_SKILL_SuperLuck
 SuperLuck:[NL]
-Use luck as crit rate.[X]
+Use Luck as crit rate.[X]
 
 ## MSG_SKILL_ShortShield
 Short Shield:[NL]
-Gain 6 defense against[NL]
+Gain 6 Defense against[NL]
 attacks recieved in melee.[X]
 
 ## MSG_SKILL_Vanity
@@ -447,17 +447,17 @@ when fighting enemy at 2 range.[X]
 
 ## MSG_SKILL_Skyguard
 Skyguard:[NL]
-+4 defense against flying enemies[NL]
++4 Defense against flying enemies[NL]
 if within 3 spaces of an ally flier.[X]
 
 ## MSG_SKILL_Horseguard
 Horseguard:[NL]
-+4 defense against horseback enemies[NL]
++4 Defense against horseback enemies[NL]
 if within 3 spaces of an ally horse rider.[X]
 
 ## MSG_SKILL_Armorboost
 Armorboost:[NL]
-+4 atk/def against armored enemies[NL]
++4 ATK/DEF against armored enemies[NL]
 if within 3 spaces of an armored ally.[X]
 
 ## MSG_SKILL_Analytic

--- a/Contants/Texts/Source/texts/Skills_Blow.txt
+++ b/Contants/Texts/Source/texts/Skills_Blow.txt
@@ -1,39 +1,39 @@
 ## MSG_SKILL_BlowDarting
 Darting Blow:[NL]
-If unit initiates combat, [NL]
-grants AS +6 during combat[X]
+If unit initiates combat,[NL]
+grants +6 AS during combat.[X]
 
 ## MSG_SKILL_BlowDeath
 Death Blow:[NL]
 If unit initiates combat,[NL]
-grants Str +6 during combat[X]
+grants +6 STR during combat.[X]
 
 ## MSG_SKILL_BlowArmored
 Armored Blow:[NL]
 If unit initiates combat,[NL]
-grants Def +6 during combat[X]
+grants +6 DEF during combat.[X]
 
 ## MSG_SKILL_BlowFiendish
 Fiendish Blow:[NL]
 If unit initiates combat,[NL]
-grants Mag +6 during combat[X]
+grants +6 MAG during combat.[X]
 
 ## MSG_SKILL_BlowWarding
 Warding Blow:[NL]
 If unit initiates combat,[NL]
-grants Res +6 during combat[X]
+grants +6 RES during combat.[X]
 
 ## MSG_SKILL_BlowDuelist
 Duelist Blow:[NL]
 If unit initiates combat,[NL]
-grants Avo +20 during combat[X]
+grants +20 Avoid during combat.[X]
 
 ## MSG_SKILL_BlowUncanny
 Uncanny Blow:[NL]
 If unit initiates combat,[NL]
-grants Hit +30 during combat[X]
+grants +30 Hit during combat.[X]
 
 ## MSG_SKILL_BlowKilling
 Killing Blow:[NL]
 If unit initiates combat,[NL]
-grants Crit +20 during combat[X]
+grants +20 Crit during combat.[X]

--- a/Contants/Texts/Source/texts/Skills_Debuff.txt
+++ b/Contants/Texts/Source/texts/Skills_Debuff.txt
@@ -2,94 +2,94 @@
 Aversa[X]
 
 ## MSG_SKILL_DEBUFF_Aversa
-Aversa's Night: if enemy's HP < unit's[NL]
+Aversa's Night: If enemy's HP < unit's[NL]
 HP -3 and have allies in 2x2, inflicts[NL]
-Atk/Spd/Def/Res-3 and caught Panic.[X]
+ATK/SPD/DEF/RES -3 and inflict Panic.[X]
 
 ## MSG_SKILL_PowHone_NAME
 Pow Open[X]
 
 ## MSG_SKILL_PowHone
 Pow Hone: Grants allies in 2x2[NL]
-Pow+4 for one turn during each[NL]
-start of turn[X]
++4 STR for one turn during the[NL]
+start of each turn.[X]
 
 ## MSG_SKILL_MagHone_NAME
 Mag Open[X]
 
 ## MSG_SKILL_MagHone
 Mag Hone: Grants allies in 2x2[NL]
-Mag+4 for one turn during each[NL]
-start of turn[X]
++4 MAG for one turn during the[NL]
+start of each turn.[X]
 
 ## MSG_SKILL_SklHone_NAME
 Skl Open[X]
 
 ## MSG_SKILL_SklHone
 Skl Hone: Grants allies in 2x2[NL]
-Skl+4 for one turn during each[NL]
-start of turn[X]
++4 SKL for one turn during the[NL]
+start of each turn.[X]
 
 ## MSG_SKILL_SpdHone_NAME
 Spd Open[X]
 
 ## MSG_SKILL_SpdHone
 Spd Hone: Grants allies in 2x2[NL]
-Spd+4 for one turn during each[NL]
-start of turn[X]
++4 SPD for one turn during the[NL]
+start of each turn.[X]
 
 ## MSG_SKILL_LckHone_NAME
 Lck Open[X]
 
 ## MSG_SKILL_LckHone
 Lck Hone: Grants allies in 2x2[NL]
-Lck+4 for one turn during each[NL]
-start of turn[X]
++4 LUCK for one turn during the[NL]
+start of each turn.[X]
 
 ## MSG_SKILL_DefHone_NAME
 Def Open[X]
 
 ## MSG_SKILL_DefHone
 Def Hone: Grants allies in 2x2[NL]
-Def+4 for one turn during each[NL]
-start of turn[X]
++4 DEF for one turn during the[NL]
+start of each turn.[X]
 
 ## MSG_SKILL_ResHone_NAME
 Res Open[X]
 
 ## MSG_SKILL_ResHone
 Res Hone: Grants allies in 2x2[NL]
-Res+4 for one turn during each[NL]
-start of turn[X]
+Res+4 for one turn during the[NL]
+start of each turn.[X]
 
 ## MSG_SKILL_HoneCavalry_NAME
 H-Cavalry[X]
 
 ## MSG_SKILL_HoneCavalry
 Hone Cavalry: Grants Cavalry allies[NL]
-in 2x2 get buff atk/spd+6 at[NL]
-each start of turn[X]
+in 2x2 +6 ATK/SPD at the start[NL]
+of each turn.[X]
 
 ## MSG_SKILL_HoneFlier_NAME
 Hone Flier[X]
 
 ## MSG_SKILL_HoneFlier
 Hone Flier: Grants Flier allies[NL]
-in 2x2 get buff atk/spd+6 at[NL]
-each start of turn[X]
+in 2x2 +6 ATK/SPD at the start[NL]
+of each turn.[X]
 
 ## MSG_SKILL_HoneArmor_NAME
 Hone Armor[X]
 
 ## MSG_SKILL_HoneArmor
 Hone Armor: Grants Armor allies[NL]
-in 2x2 get buff atk/spd+6 at[NL]
-each start of turn[X]
+in 2x2 +6 ATK/SPD at the start[NL]
+of each turn.[X]
 
 ## MSG_SKILL_FortifyArmor_NAME
 Fortify Armor[X]
 
 ## MSG_SKILL_FortifyArmor
 Fortify Armor: Grants Armor allies[NL]
-in 2x2 get buff atk/spd+6 at[NL]
-each start of turn[X]
+in 2x2 +6 ATK/SPD at the start[NL]
+of each turn.[X]

--- a/Contants/Texts/Source/texts/Skills_Legend.txt
+++ b/Contants/Texts/Source/texts/Skills_Legend.txt
@@ -1,14 +1,14 @@
 ## MSG_SKILL_LEGEND_InoriAtk
 Legend:(once per chapter)[NL]
-If attacked to 0 Hp, unit may[NL]
-not die but atk+10, crit+100%[X]
+If attacked to 0 HP, unit will survive[NL]
+and receive +10 ATK, Crit +100%[X]
 
 ## MSG_SKILL_LEGEND_InoriAvo
 Legend:(once per chapter)[NL]
-If attacked to 0 Hp, unit may[NL]
-not die but spd+10, avo+100%[X]
+If attacked to 0 HP, unit will[NL]
+survive and receive +10 SPD, AVO +100%[X]
 
 ## MSG_SKILL_LEGEND_InoriDef
 Legend:(once per chapter)[NL]
-If attacked to 0 Hp, unit may not[NL]
-die, recover hp and def/res +10[X]
+If attacked to 0 HP, unit will survive,[NL]
+recover HP and receive +10 DEF/RES.[X]

--- a/Contants/Texts/Source/texts/Skills_Lvup.txt
+++ b/Contants/Texts/Source/texts/Skills_Lvup.txt
@@ -1,15 +1,19 @@
 ## MSG_SKILL_Blossom
-Blossom: 2x growth rates,[NL]
-but 1/2 exp gain.[X]
+Blossom:[NL]
+2x growth rates,[NL]
+but 1/2 EXP gain.[X]
 
 ## MSG_SKILL_Paragon
-Paragon: Experience gain[NL]
+Paragon:[NL]
+Experience gained[NL]
 is doubled.[X]
 
 ## MSG_SKILL_VoidCurse
-V-Curse: This unit gives[NL]
-no experience when defeated.[X]
+V-Curse:[NL]
+This unit gives no[NL]
+experience when defeated.[X]
 
 ## MSG_SKILL_Aptitude
-Aptitude: +20% to[NL]
-all growth rates.[X]
+Aptitude:[NL]
++20% to all[NL]
+growth rates.[X]

--- a/Contants/Texts/Source/texts/Skills_Menu.txt
+++ b/Contants/Texts/Source/texts/Skills_Menu.txt
@@ -1,21 +1,24 @@
 ## MSG_SKILL_Dance
 Dance:[NL]
-Unit can dance[X]
+Unit can use
+"Dance" command.[X]
 
 ## MSG_SKILL_LockTouch
 Lock Touch:[NL]
 Unit can use[NL]
-"Pick" command[X]
+"Pick" command.[X]
 
 ## MSG_SKILL_Summon
 Summon:[NL]
 Unit can use[NL]
-"Summon" command[X]
+"Summon" command.[X]
 
 ## MSG_SKILL_Supply
 Supply:[NL]
-Unit has Supply[X]
+Unit can use[NL]
+"Supply" command.[X]
 
 ## MSG_SKILL_Steal
 Steal:[NL]
-Unit can steal items[X]
+Unit can use[NL]
+"Steal" command.[X]

--- a/Contants/Texts/Source/texts/Skills_PostAction.txt
+++ b/Contants/Texts/Source/texts/Skills_PostAction.txt
@@ -1,25 +1,25 @@
 ## MSG_SKILL_Canto
 Canto:[NL]
-Unit can move again[X]
+Unit can move again.[X]
 
 ## MSG_SKILL_CantoPlus
 Canto:[NL]
-Unit can move again after combat[X]
+Unit can move again after combat.[X]
 
 ## MSG_SKILL_AlertStance
 A-Stance:[NL]
 If unit takes no action[NL]
-except Wait, grants Avo +15%[X]
+except Wait, grants Avoid +15%.[X]
 
 ## MSG_SKILL_AlertStancePlus
 A-Stance+:[NL]
 If unit takes no action[NL]
-except Wait, grants Avo +30%[X]
+except Wait, grants Avoid +30%.[X]
 
 ## MSG_SKILL_Galeforce
 Galeforce: Move again after[NL]
 attacking and defeating an enemy.[NL]
-(Skill% activation)[X]
+(Skill % activation)[X]
 
 ## MSG_SKILL_SavageBlow
 Savage Blow:[NL]
@@ -29,29 +29,30 @@ within 2 tiles take 20% damage.[X]
 ## MSG_SKILL_BreathOfLife
 Breath Life:[NL]
 After attacking, allies[NL]
-in 2 tiles heal of 20% max HP.[X]
+in 2 tiles heal for 20% their max HP.[X]
 
 ## MSG_SKILL_Thunderstorm_NAME
 Thunder[X]
 
 ## MSG_SKILL_Thunderstorm
 Thunderstorm:[NL]
-When hit from 3 range away, call[NL]
-an AOE thunder at enemy location.[X]
+When targeting enemies from 3 tiles away,[NL]
+call an AOE thunder at the enemy location.[X]
 
 ## MSG_SKILL_PosReturn
 Return:[NL]
-If enemy defeated, return[NL]
-to the original position.[X]
+If the enemy is defeated, you can[NL]
+return to your starting position.[X]
 
 ## MSG_SKILL_PosSwap
 Swap:[NL]
-Swap position after[NL]
-attacking enemy.[X]
+Swap positions with the enemy[NL]
+after attacking them.[X]
 
 ## MSG_SKILL_Synchronize
-Synchronize: put status of[NL]
-the character to the target[X]
+Synchronize: 
+Copy status of unit to target.[NL]
+Allies only get buffs, and vice-versa.[X]
 
 ## MSG_SKILL_Lifetaker
 Lifetaker:[NL]

--- a/Contants/Texts/Source/texts/Skills_PrePhase.txt
+++ b/Contants/Texts/Source/texts/Skills_PrePhase.txt
@@ -5,7 +5,7 @@ at the start of each turn.[X]
 
 ## MSG_SKILL_Imbue
 Imbue:[NL]
-Recover HP equal to Magic[NL]
+Recover HP equal to MAG[NL]
 at the start of each turn.[X]
 
 ## MSG_SKILL_Forager

--- a/Contants/Texts/Source/texts/Skills_RangeDebuff.txt
+++ b/Contants/Texts/Source/texts/Skills_RangeDebuff.txt
@@ -5,7 +5,7 @@ enemies within 3 tiles.[X]
 
 ## MSG_SKILL_Bond
 Bond:[NL]
-+10 hit, +3 damage to all[NL]
++10 Hit, +3 damage to all[NL]
 allies within 3 tiles.[X]
 
 ## MSG_SKILL_Intimidate
@@ -20,12 +20,12 @@ no allies within 3 tiles.[X]
 
 ## MSG_SKILL_Focus
 Focus:[NL]
-+10 Critical if there are[NL]
++10 Crit if there are[NL]
 no allies within 3 tiles.[X]
 
 ## MSG_SKILL_Hex
 Hex:[NL]
--15 avoid to all[NL]
+-15 Avoid to all[NL]
 adjacent enemies.[X]
 
 ## MSG_SKILL_Charm
@@ -35,7 +35,7 @@ tiles deal +3 attack.[X]
 ## MSG_SKILL_Infiltrator
 Infilt: If within 2 spaces[NL]
 of two or more enemies, gain +3[NL]
-damage and +15% hit.[X]
+damage and +15% Hit.[X]
 
 ## MSG_SKILL_Inspiration
 Inspir: Allies within 2 tiles[NL]
@@ -55,15 +55,15 @@ V-Peace: Enemies within[NL]
 2 tiles deal -2 damage.[X]
 
 ## MSG_SKILL_BattleRange1
-Range Skill: Atk +10 if[NL]
+Range Skill: ATK +10 if[NL]
 no ally with 3 tiles.[X]
 
 ## MSG_SKILL_BattleRange2
-Range Skill: Atk +7 if[NL]
+Range Skill: ATK +7 if[NL]
 no ally with 2 tiles.[X]
 
 ## MSG_SKILL_BattleRange3
-Range Skill: Atk +5 if[NL]
+Range Skill: ATK +5 if[NL]
 no ally with 1 tiles.[X]
 
 ## MSG_SKILL_Peacebringer
@@ -73,23 +73,23 @@ Allies and enemies within[NL]
 
 ## MSG_SKILL_DriveStr
 Drive Str:[NL]
-Allies within 2 tiles receive +4 Strength.[X]
+Allies within 2 tiles receive +4 STR.[X]
 
 ## MSG_SKILL_DriveMag
 Drive Mag:[NL]
-Allies within 2 tiles receive +4 Magic.[X]
+Allies within 2 tiles receive +4 MAG.[X]
 
 ## MSG_SKILL_DriveSpd
 Drive Spd:[NL]
-Allies within 2 tiles receive +4 Speed.[X]
+Allies within 2 tiles receive +4 SPD.[X]
 
 ## MSG_SKILL_DriveDef
 Drive Def:[NL]
-Allies within 2 tiles receive +4 Defence.[X]
+Allies within 2 tiles receive +4 DEF.[X]
 
 ## MSG_SKILL_DriveRes
 Drive Res:[NL]
-Allies within 2 tiles receive +4 Resistance.[X]
+Allies within 2 tiles receive +4 RES.[X]
 
 ## MSG_SKILL_Charisma
 Charisma:[NL]
@@ -102,38 +102,38 @@ units in a 3-tile radius.[X]
 
 ## MSG_SKILL_BloodTide
 Blood Tide:[NL]
-Grants Atk and Hit +5[NL]
+Grants +5 ATK and Hit[NL]
 to adjacent allies.[X]
 
 ## MSG_SKILL_WhitePool
 White Pool:[NL]
-Grants Atk and AS +5[NL]
+Grants +5 ATK and AS[NL]
 to adjacent allies.[X]
 
 ## MSG_SKILL_NightTide
 Night Tide:[NL]
-Grants +5 Def and Res[NL]
-to adjacent allies[X]
+Grants +5 DEF and RES[NL]
+to adjacent allies.[X]
 
 ## MSG_SKILL_SpurStr
 Spur Str:[NL]
-Adjacent allies gain +4 Strength.[X]
+Adjacent allies gain +4 STR.[X]
 
 ## MSG_SKILL_SpurMag
 Spur Mag:[NL]
-Adjacent allies gain +4 Magic.[X]
+Adjacent allies gain +4 MAG.[X]
 
 ## MSG_SKILL_SpurSpd
 Spur Spd:[NL]
-Adjacent allies gain +4 Speed.[X]
+Adjacent allies gain +4 SPD.[X]
 
 ## MSG_SKILL_SpurDef
 Spur Def:[NL]
-Adjacent allies gain +4 Defence.[X]
+Adjacent allies gain +4 DEF.[X]
 
 ## MSG_SKILL_SpurRes
 Spur Res:[NL]
-Adjacent allies gain +4 Resistance.[X]
+Adjacent allies gain +4 RES.[X]
 
 ## MSG_SKILL_Gentilhomme
 Gentilhomme:[NL]
@@ -145,4 +145,4 @@ Male allies within 2 tiles receive -2 damage.[X]
 
 ## MSG_SKILL_Solidarity
 Solidarity:[NL]
-Critical and Critical Avoid +10 to adjacent allies.[X]
++10 Crit and Crit Avoid to adjacent allies.[X]

--- a/Contants/Texts/Source/texts/Skills_Stance.txt
+++ b/Contants/Texts/Source/texts/Skills_Stance.txt
@@ -1,57 +1,57 @@
 ## MSG_SKILL_StanceBracing
 S-Bracing:[NL]
-Grants Def and Res +4[NL]
-if attacked[X]
+Grants +4 DEF and RES[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceDarting
 S-Darting:[NL]
-Grants AS +6[NL]
-if attacked[X]
+Grants +6 AS[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceFierce
 S-Fierce:[NL]
-Grants Atk +6[NL]
-if attacked[X]
+Grants +6 ATK[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceKestrel
 S-Kestrel:[NL]
-Grants Atk and AS +4[NL]
-if attacked[X]
+Grants +4 ATK and AS[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceMirror
 S-Mirror:[NL]
-Grants Atk and Res +4[NL]
-if attacked[X]
+Grants +4 ATK and RES[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceReady
 S-Ready:[NL]
-Grants AS and Def +4[NL]
-if attacked[X]
+Grants +4 AS and DEF[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceSteady
 S-Steady:[NL]
-Grants Def +6[NL]
-if attacked[X]
+Grants +6 DEF[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceSturdy
 S-Sturdy:[NL]
-Grants Atk and Def +4[NL]
-if attacked[X]
+Grants +4 ATK and DEF[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceSwift
 S-Swift:[NL]
-Grants AS and Res +4[NL]
-if attacked[X]
+Grants +4 AS and RES[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceWarding
 S-Warding:[NL]
-Grants Res +6[NL]
-if attacked[X]
+Grants +6 RES[NL]
+if attacked.[X]
 
 ## MSG_SKILL_StanceSpectrum_NAME
 S-Spectrum[X]
 
 ## MSG_SKILL_StanceSpectrum
 Stance Spectrum:[NL]
-Grants +2 Atk, Spd, Def[NL]
-and Res if attacked.[X]
+Grants +2 ATK, SPD, DEF[NL]
+and RES if attacked.[X]

--- a/Contants/Texts/Source/texts/Skills_StatusGetter.txt
+++ b/Contants/Texts/Source/texts/Skills_StatusGetter.txt
@@ -1,158 +1,158 @@
 ## MSG_SKILL_LifeAndDeath
 Life-Death:[NL]
-Pow and Mag +5[NL]
-Def and Res -5[X]
+For both unit and enemy,[NL]
+STR/MAG +5, DEF/RES -5.[X]
 
 ## MSG_SKILL_Fury
-Fury: [NL]
-Unit Status+3, HP-6 after combat[X]
+Fury:[NL]
+All stats +3, HP -6 after combat.[X]
 
 ## MSG_SKILL_FuryPlus
-Fury+: [NL]
-Unit Status+4, HP-8 after combat[X]
+Fury+:[NL]
+All stats +4, HP -8 after combat.[X]
 
 ## MSG_SKILL_FortressDef
-Fortress Def: [NL]
-Str and Mag -3, Def +5[X]
+Fortress Def:[NL]
+STR/MAG -3, DEF +5.[X]
 
 ## MSG_SKILL_FortressRes
-Fortress Res: [NL]
-Str and Mag -3, Res +5[X]
+Fortress Res:[NL]
+STR/MAG -3, RES +5.[X]
 
 ## MSG_SKILL_HpBonus
-Hp+5: [NL]
-Unit grants bonus Hp+2[X]
+Hp+5:[NL]
+Unit is granted HP +5.[X]
 
 ## MSG_SKILL_StrBonus
-Str+2: [NL]
-Unit grants bonus Str+2[X]
+Str+2:[NL]
+Unit is granted STR +2.[X]
 
 ## MSG_SKILL_MagBonus
-Mag+2: [NL]
-Unit grants bonus Mag+2[X]
+Mag+2:[NL]
+Unit is granted MAG +2.[X]
 
 ## MSG_SKILL_SklBonus
-Skl+2: [NL]
-Unit grants bonus Skl+2[X]
+Skl+2:[NL]
+Unit is granted SKL +2.[X]
 
 ## MSG_SKILL_SpdBonus
-Spd+2: [NL]
-Unit grants bonus Spd+2[X]
+Spd+2:[NL]
+Unit is granted SPD +2.[X]
 
 ## MSG_SKILL_LukBonus
-Luk+2: [NL]
-Unit grants bonus Luk+2[X]
+Luck+2:[NL]
+Unit is granted LUCK +2.[X]
 
 ## MSG_SKILL_DefBonus
-Def+2: [NL]
-Unit grants bonus Def+2[X]
+Def+2:[NL]
+Unit is granted DEF +2.[X]
 
 ## MSG_SKILL_ResBonus
-Res+2: [NL]
-Unit grants bonus Res+2[X]
+Res+2:[NL]
+Unit is granted RES +2.[X]
 
 ## MSG_SKILL_MovBonus
-Mov+2: [NL]
-Unit grants bonus Mov+2[X]
+Mov+2:[NL]
+Unit is granted MOV +2.[X]
 
 ## MSG_SKILL_DefiantCrit
-Defiant Crit: [NL]
-Crit rate +50%,[NL]
-if HP <25%[X]
+Defiant Crit:[NL]
+Crit Rate +50%,[NL]
+if HP < 25%.[X]
 
 ## MSG_SKILL_DefiantAvoid
-Defiant Avoid: [NL]
-Avoid rate +30%,[NL]
-if HP <25%[X]
+Defiant Avoid:[NL]
+Avoid Rate +30%,[NL]
+if HP < 25%.[X]
 
 ## MSG_SKILL_DefiantStr
-Defiant Str: [NL]
-Pow +7 if HP <25%[X]
+Defiant Str:[NL]
+STR +7 if HP < 25%[X]
 
 ## MSG_SKILL_DefiantMag
 Defiant Mag: [NL]
-Mag +7 if HP <25%[X]
+MAG +7 if HP < 25%[X]
 
 ## MSG_SKILL_DefiantSkl
 Defiant Skl: [NL]
-Skl +7 if HP <25%[X]
+SKL +7 if HP < 25%[X]
 
 ## MSG_SKILL_DefiantSpd
 Defiant Spd: [NL]
-Spd +7 if HP <25%[X]
+SPD +7 if HP < 25%[X]
 
 ## MSG_SKILL_DefiantLck
 Defiant Luk: [NL]
-Luk +7 if HP <25%[X]
+LUCK +7 if HP < 25%[X]
 
 ## MSG_SKILL_DefiantDef
 Defiant Def: [NL]
-Def +7 if HP <25%[X]
+DEF +7 if HP < 25%[X]
 
 ## MSG_SKILL_DefiantRes
 Defiant Res: [NL]
-Res +7 if HP <25%[X]
+RES +7 if HP < 25%[X]
 
 ## MSG_SKILL_LuckySeven
 Lucky 7: [NL]
-Unit get different bonus[NL]
-at each turn[X]
+Apply a fresh +7 stat bonus
+on each subsequent turn.[NL]
 
 ## MSG_SKILL_PushDefense_NAME
 P-Defense[X]
 
 ## MSG_SKILL_PushDefense
 PushDefense:[NL]
-+5 defense if HP is full.[X]
++5 DEF if HP is full.[X]
 
 ## MSG_SKILL_PushMagic_NAME
 P-Magic[X]
 
 ## MSG_SKILL_PushMagic
 PushMagic:[NL]
-+5 Magic if HP is full.[X]
++5 MAG if HP is full.[X]
 
 ## MSG_SKILL_PushResistance_NAME
 P-Resistance[X]
 
 ## MSG_SKILL_PushResistance
 Push Resistance:[NL]
-+5 resistance when HP is full.[X]
++5 RES when HP is full.[X]
 
 ## MSG_SKILL_PushSkill_NAME
 P-Skill[X]
 
 ## MSG_SKILL_PushSkill
 Push Skill:[NL]
-+5 skill if HP is full.[X]
++5 SKL if HP is full.[X]
 
 ## MSG_SKILL_PushSpeed_NAME
 P-Speed[X]
 
 ## MSG_SKILL_PushSpeed
 Push Speed:[NL]
-+5 speed if HP is full.[X]
++5 SPD if HP is full.[X]
 
 ## MSG_SKILL_PushStrength_NAME
 P-Strength[X]
 
 ## MSG_SKILL_PushStrength
 Push Strength:[NL]
-+5 strength if HP is full.[X]
++5 STR if HP is full.[X]
 
 ## MSG_SKILL_PushLuck_NAME
 P-Luck[X]
 
 ## MSG_SKILL_PushLuck
 Push Luck:[NL]
-+5 to luck if HP is full.[X]
++5 LUCK if HP is full.[X]
 
 ## MSG_SKILL_PushMovement_NAME
 P-Movement[X]
 
 ## MSG_SKILL_PushMovement
 Push Movement:[NL]
-+5 movement if HP is full.[X]
++5 MOV if HP is full.[X]
 
 ## MSG_SKILL_PushSpectrum_NAME
 P-Spectrum[X]
@@ -163,30 +163,30 @@ Push Spectrum:[NL]
 
 ## MSG_SKILL_EvenFooted
 EvenFooted:[NL]
-+1 move on even[NL]
++1 MOV on even[NL]
 numbered turns.[X]
 
 ## MSG_SKILL_OddFooted
 OddFooted:[NL]
-+1 move on odd[NL]
++1 MOV on odd[NL]
 numbered turns.[X]
 
 ## MSG_SKILL_Resolve
 Resolve:[NL]
 When HP < 50%,[NL]
-Str/Skl/Spd +50% bonus.[X]
+STR/SKL/SPD +50% bonus.[X]
 
 ## MSG_SKILL_SpeedBoost
 SpeedBoost:[NL]
-+1 movement per turn up[NL]
-to a maximum of  turns.[X]
++1 MOV per turn up[NL]
+to a maximum of 6 turns.[X]
 
 ## MSG_SKILL_InitCalm_NAME
 Calm-Init.[X]
 
 ## MSG_SKILL_InitCalm
 Calm Initiative:[NL]
-+7 to RES at the[NL]
++7 RES at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitStrong_NAME
@@ -194,7 +194,7 @@ Strong-Init.[X]
 
 ## MSG_SKILL_InitStrong
 Strong Initiative:[NL]
-+7 to STR at the[NL]
++7 STR at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitDeft_NAME
@@ -202,7 +202,7 @@ Deft-Init.[X]
 
 ## MSG_SKILL_InitDeft
 Deft Initiative:[NL]
-+7 to SKL at the[NL]
++7 SKL at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitQuick_NAME
@@ -210,7 +210,7 @@ Quick-Init.[X]
 
 ## MSG_SKILL_InitQuick
 Quick Initiative:[NL]
-+7 to SPD at the[NL]
++7 SPD at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitSturdy_NAME
@@ -218,7 +218,7 @@ Sturdy-Init.[X]
 
 ## MSG_SKILL_InitSturdy
 Sturdy Initiative:[NL]
-+7 to DEF at the[NL]
++7 DEF at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitClever_NAME
@@ -226,7 +226,7 @@ Clever-Init.[X]
 
 ## MSG_SKILL_InitClever
 Clever Initiative:[NL]
-+7 to MAG at the[NL]
++7 MAG at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitLucky_NAME
@@ -234,7 +234,7 @@ Lucky-Init.[X]
 
 ## MSG_SKILL_InitLucky
 Lucky Initiative:[NL]
-+7 to LUCK at the[NL]
++7 LUCK at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitNimble_NAME
@@ -242,7 +242,7 @@ Nimble-Init.[X]
 
 ## MSG_SKILL_InitNimble
 Nimble Initiative:[NL]
-+7 to MOV at the[NL]
++7 MOV at the[NL]
 beginning of the turn.[X]
 
 ## MSG_SKILL_InitSpectrum_NAME

--- a/Contants/Texts/Source/texts/Skills_WeaponTriangle.txt
+++ b/Contants/Texts/Source/texts/Skills_WeaponTriangle.txt
@@ -1,23 +1,23 @@
 ## MSG_SKILL_SwordBreaker
-Sword Brek:[NL]
-Hit, avoid +20% if[NL]
-attack sowrd with lance[X]
+Sword Break:[NL]
+Hit and Avoid +20% if unit[NL]
+battles a Sword with a Lance.[X]
 
 ## MSG_SKILL_AxeBreaker
 Axe Break:[NL]
-Hit, avoid +20% if[NL]
-attack axe with sword[X]
+Hit and Avoid +20% if unit[NL]
+battles an Axe with a Sword.[X]
 
 ## MSG_SKILL_LanceBreaker
-Lance Brek:[NL]
-Hit, avoid +20% if[NL]
-attack lance with axe[X]
+Lance Break:[NL]
+Hit and Avoid +20% if unit[NL]
+battles a Lance with an Axe.[X]
 
 ## MSG_SKILL_BowBreaker
 Bow Break: [NL]
-Hit, avoid +20% if[NL]
-attack bow with B.mag[X]
+Hit and Avoid +20% if unit[NL]
+battles a Bow with B.mag.[X]
 
 ## MSG_SKILL_BMagBreaker
-B.Mag Brek: [NL]
-Hit, avoid +20%[X]
+B.Mag Break: [NL]
+Hit and Avoid +20%.[X]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Modern CHAX for FE8U-SkillSystem, including skillsys, battle-system hacks, etc.e
 > [!NOTE]
 > You need a linux envirment!
 >
-> For Windows user, it is recommended to use a [Ubuntu Server](https://ubuntu.com/aws) or try [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+> For Windows users, it is recommended to use a [Ubuntu Server](https://ubuntu.com/aws) or try [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 1. Install sub-modules
 
@@ -24,7 +24,7 @@ git clone https://github.com/StanHash/EventAssembler.git --recursive
 git clone https://github.com/StanHash/FE-PyTools.git --recursive
 ```
 
-2. Install dependence
+2. Install dependencies
 
 ```bash
 sudo apt-get -y install binutils-arm-none-eabi \

--- a/Wizardry/Core/BattleSys/Source/BattleHit.c
+++ b/Wizardry/Core/BattleSys/Source/BattleHit.c
@@ -12,7 +12,7 @@
 STATIC_DECLAR bool CheckSkillHpDrain(struct BattleUnit * attacker, struct BattleUnit * defender)
 {
 #if (defined(SID_Aether) && (COMMON_SKILL_VALID(SID_Aether)))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Aether, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Aether, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Aether);
         return true;
@@ -20,7 +20,7 @@ STATIC_DECLAR bool CheckSkillHpDrain(struct BattleUnit * attacker, struct Battle
 #endif
 
 #if (defined(SID_Sol) && (COMMON_SKILL_VALID(SID_Sol)))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Sol, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Sol, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Sol);
         return true;
@@ -51,7 +51,7 @@ void BattleUpdateBattleStats(struct BattleUnit * attacker, struct BattleUnit * d
     }
 
 #if defined(SID_AxeFaith) && (COMMON_SKILL_VALID(SID_AxeFaith))
-    if (attacker->weaponType == ITYPE_AXE && CheckBattleSkillActivte(attacker, defender, SID_AxeFaith, attacker->battleAttack))
+    if (attacker->weaponType == ITYPE_AXE && CheckBattleSkillActivate(attacker, defender, SID_AxeFaith, attacker->battleAttack))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_AxeFaith);
         hitRate += attacker->battleAttack;
@@ -61,7 +61,7 @@ void BattleUpdateBattleStats(struct BattleUnit * attacker, struct BattleUnit * d
     gBattleTemporaryFlag.skill_activated_sure_shoot = false;
 
 #if (defined(SID_SureShot) && (COMMON_SKILL_VALID(SID_SureShot)))
-    if (CheckBattleSkillActivte(attacker, defender, SID_SureShot, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_SureShot, attacker->unit.skl))
     {
         gBattleTemporaryFlag.skill_activated_sure_shoot = true;
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_SureShot);
@@ -72,7 +72,7 @@ void BattleUpdateBattleStats(struct BattleUnit * attacker, struct BattleUnit * d
     gBattleTemporaryFlag.skill_activated_dead_eye = false;
 
 #if defined(SID_Deadeye) && (COMMON_SKILL_VALID(SID_Deadeye))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Deadeye, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Deadeye, attacker->unit.skl))
     {
         gBattleTemporaryFlag.skill_activated_dead_eye = true;
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Deadeye);
@@ -128,7 +128,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
     if (!BattleRoll2RN(gBattleStats.hitRate, FALSE))
     {
 #if (defined(SID_DivinePulse) && (COMMON_SKILL_VALID(SID_DivinePulse)))
-        if (CheckBattleSkillActivte(attacker, defender, SID_DivinePulse, 30 + attacker->unit.lck))
+        if (CheckBattleSkillActivate(attacker, defender, SID_DivinePulse, 30 + attacker->unit.lck))
             RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_DivinePulse);
         else
         {
@@ -188,7 +188,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
 #endif
 
 #if (defined(SID_Flare) && (COMMON_SKILL_VALID(SID_Flare)))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Flare, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Flare, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Flare);
         defense = defense / 2;
@@ -198,7 +198,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
     if (IsMagicAttack(attacker))
     {
 #if (defined(SID_Corona) && (COMMON_SKILL_VALID(SID_Corona)))
-        if (CheckBattleSkillActivte(attacker, defender, SID_Corona, attacker->unit.skl))
+        if (CheckBattleSkillActivate(attacker, defender, SID_Corona, attacker->unit.skl))
         {
             RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Corona);
             defense = 0;
@@ -208,7 +208,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
     else
     {
 #if (defined(SID_Luna) && (COMMON_SKILL_VALID(SID_Luna)))
-        if (CheckBattleSkillActivte(attacker, defender, SID_Luna, attacker->unit.skl))
+        if (CheckBattleSkillActivate(attacker, defender, SID_Luna, attacker->unit.skl))
         {
             RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Luna);
             defense = 0;
@@ -217,7 +217,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
     }
 
 #if (defined(SID_Ignis) && (COMMON_SKILL_VALID(SID_Ignis)))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Ignis, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Ignis, attacker->unit.skl))
     {
         RegisterTargetEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Ignis);
         switch (attacker->weaponType) {
@@ -240,7 +240,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
 #endif
 
 #if defined(SID_Glacies) && (COMMON_SKILL_VALID(SID_Glacies))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Glacies, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Glacies, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Glacies);
         attack += attacker->unit.res;
@@ -248,7 +248,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
 #endif
 
 #if defined(SID_Vengeance) && (COMMON_SKILL_VALID(SID_Vengeance))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Vengeance, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Vengeance, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Vengeance);
         attack += (attacker->unit.maxHP - attacker->unit.curHP);
@@ -270,7 +270,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
 #endif
 
 #if (defined(SID_Colossus) && (COMMON_SKILL_VALID(SID_Colossus)))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Colossus, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Colossus, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Colossus);
         amplifier += 200;
@@ -279,7 +279,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
 #endif
 
 #if defined(SID_Impale) && (COMMON_SKILL_VALID(SID_Impale))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Impale, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Impale, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Impale);
         amplifier += 300;
@@ -318,7 +318,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
     if (damage > 0)
     {
 #if (defined(SID_GreatShield) && (COMMON_SKILL_VALID(SID_GreatShield)))
-            if (CheckBattleSkillActivte(defender, attacker, SID_GreatShield, defender->unit.skl))
+            if (CheckBattleSkillActivate(defender, attacker, SID_GreatShield, defender->unit.skl))
             {
                 RegisterTargetEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_GreatShield);
                 damage = 0;
@@ -327,7 +327,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
         if (IsMagicAttack(attacker))
         {
 #if (defined(SID_Aegis) && (COMMON_SKILL_VALID(SID_Aegis)))
-            if (CheckBattleSkillActivte(defender, attacker, SID_Aegis, defender->unit.skl))
+            if (CheckBattleSkillActivate(defender, attacker, SID_Aegis, defender->unit.skl))
             {
                 RegisterTargetEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Aegis);
                 damage = 0;
@@ -337,7 +337,7 @@ void BattleGenerateHitAttributes(struct BattleUnit * attacker, struct BattleUnit
         else
         {
 #if (defined(SID_Pavise) && (COMMON_SKILL_VALID(SID_Pavise)))
-            if (CheckBattleSkillActivte(defender, attacker, SID_Pavise, defender->unit.skl))
+            if (CheckBattleSkillActivate(defender, attacker, SID_Pavise, defender->unit.skl))
             {
                 RegisterTargetEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Pavise);
                 damage = 0;
@@ -444,7 +444,7 @@ void BattleGenerateHitEffects(struct BattleUnit * attacker, struct BattleUnit * 
 #if defined(SID_Bane) && (COMMON_SKILL_VALID(SID_Bane))
             if (gBattleStats.damage < (defender->unit.curHP - 1))
             {
-                if (CheckBattleSkillActivte(attacker, defender, SID_Bane, attacker->unit.skl))
+                if (CheckBattleSkillActivate(attacker, defender, SID_Bane, attacker->unit.skl))
                 {
                     RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Bane);
                     gBattleStats.damage = defender->unit.curHP - 1;
@@ -527,7 +527,7 @@ void BattleGenerateHitEffects(struct BattleUnit * attacker, struct BattleUnit * 
      * Consume enemy weapons
      */
 #if (defined(SID_Corrosion) && (COMMON_SKILL_VALID(SID_Corrosion)))
-    if (!(gBattleHitIterator->attributes & BATTLE_HIT_ATTR_MISS) && CheckBattleSkillActivte(attacker, defender, SID_Corrosion, attacker->unit.skl))
+    if (!(gBattleHitIterator->attributes & BATTLE_HIT_ATTR_MISS) && CheckBattleSkillActivate(attacker, defender, SID_Corrosion, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Corrosion);
         int cost = attacker->levelPrevious;
@@ -556,7 +556,7 @@ void BattleGenerateHitEffects(struct BattleUnit * attacker, struct BattleUnit * 
         weapon_cost = true;
 
 #if defined(SID_Armsthrift) && (COMMON_SKILL_VALID(SID_Armsthrift))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Armsthrift, attacker->unit.lck))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Armsthrift, attacker->unit.lck))
     {
         weapon_cost = false;
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Armsthrift);
@@ -594,7 +594,7 @@ void BattleGenerateHitEffects(struct BattleUnit * attacker, struct BattleUnit * 
 STATIC_DECLAR bool InoriCheck(struct BattleUnit * attacker, struct BattleUnit * defender)
 {
 #if (defined(SID_Mercy) && (COMMON_SKILL_VALID(SID_Mercy)))
-    if (CheckBattleSkillActivte(attacker, defender, SID_Mercy, attacker->unit.skl))
+    if (CheckBattleSkillActivate(attacker, defender, SID_Mercy, attacker->unit.skl))
     {
         RegisterActorEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Mercy);
         return true;
@@ -602,7 +602,7 @@ STATIC_DECLAR bool InoriCheck(struct BattleUnit * attacker, struct BattleUnit * 
 #endif
 
 #if (defined(SID_Inori) && (COMMON_SKILL_VALID(SID_Inori)))
-    if (CheckBattleSkillActivte(defender, attacker, SID_Inori, defender->unit.lck))
+    if (CheckBattleSkillActivate(defender, attacker, SID_Inori, defender->unit.lck))
     {
         RegisterTargetEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Inori);
         return true;
@@ -610,7 +610,7 @@ STATIC_DECLAR bool InoriCheck(struct BattleUnit * attacker, struct BattleUnit * 
 #endif
 
 #if (defined(SID_LEGEND_InoriAtk) && (COMMON_SKILL_VALID(SID_LEGEND_InoriAtk)))
-    if (CheckBattleSkillActivte(defender, attacker, SID_LEGEND_InoriAtk, 100))
+    if (CheckBattleSkillActivate(defender, attacker, SID_LEGEND_InoriAtk, 100))
     {
         if (TryActivateLegendSkill(&defender->unit, SID_LEGEND_InoriAtk) == 0)
         {
@@ -621,7 +621,7 @@ STATIC_DECLAR bool InoriCheck(struct BattleUnit * attacker, struct BattleUnit * 
 #endif
 
 #if (defined(SID_LEGEND_InoriAvo) && (COMMON_SKILL_VALID(SID_LEGEND_InoriAvo)))
-    if (CheckBattleSkillActivte(defender, attacker, SID_LEGEND_InoriAvo, 100))
+    if (CheckBattleSkillActivate(defender, attacker, SID_LEGEND_InoriAvo, 100))
     {
         if (TryActivateLegendSkill(&defender->unit, SID_LEGEND_InoriAvo) == 0)
         {
@@ -632,7 +632,7 @@ STATIC_DECLAR bool InoriCheck(struct BattleUnit * attacker, struct BattleUnit * 
 #endif
 
 #if (defined(SID_LEGEND_InoriDef) && (COMMON_SKILL_VALID(SID_LEGEND_InoriDef)))
-    if (CheckBattleSkillActivte(defender, attacker, SID_LEGEND_InoriDef, 100))
+    if (CheckBattleSkillActivate(defender, attacker, SID_LEGEND_InoriDef, 100))
     {
         if (TryActivateLegendSkill(&defender->unit, SID_LEGEND_InoriDef) == 0)
         {
@@ -684,7 +684,7 @@ bool BattleGenerateHit(struct BattleUnit * attacker, struct BattleUnit * defende
             gBattleActorGlobalFlag.enimy_defeated = true;
 
 #if (defined(SID_Galeforce) && (COMMON_SKILL_VALID(SID_Galeforce)))
-            if (CheckBattleSkillActivte(&gBattleActor, &gBattleTarget, SID_Galeforce, gBattleActor.unit.skl))
+            if (CheckBattleSkillActivate(&gBattleActor, &gBattleTarget, SID_Galeforce, gBattleActor.unit.skl))
                 gBattleActorGlobalFlag.skill_activated_galeforce = true;
 #endif
             gBattleHitIterator->info |= BATTLE_HIT_INFO_KILLS_TARGET;

--- a/Wizardry/Core/BattleSys/Source/BattleOrder.c
+++ b/Wizardry/Core/BattleSys/Source/BattleOrder.c
@@ -391,7 +391,7 @@ int GetBattleUnitHitCount(struct BattleUnit * actor)
 #endif
 
 #if defined(SID_Astra) && (COMMON_SKILL_VALID(SID_Astra))
-    if (actor == &gBattleActor && CheckBattleSkillActivte(actor, target, SID_Astra, actor->unit.spd))
+    if (actor == &gBattleActor && CheckBattleSkillActivate(actor, target, SID_Astra, actor->unit.spd))
     {
         EnqueueRoundEfxSkill(SID_Astra);
         gBattleActorGlobalFlag.skill_activated_astra = true;

--- a/Wizardry/Core/BattleSys/Source/BattleSkillActRate.c
+++ b/Wizardry/Core/BattleSys/Source/BattleSkillActRate.c
@@ -3,7 +3,7 @@
 #include "battle-system.h"
 #include "constants/skills.h"
 
-bool CheckBattleSkillActivte(struct BattleUnit * actor, struct BattleUnit * target, int sid, int rate)
+bool CheckBattleSkillActivate(struct BattleUnit * actor, struct BattleUnit * target, int sid, int rate)
 {
     if (gBattleStats.config & BATTLE_CONFIG_SIMULATE)
         return false;

--- a/docs/Memory.md
+++ b/docs/Memory.md
@@ -18,7 +18,7 @@ In order to collaborate with FEBuilderGBA and make DEMO based on kernel, we also
 
 ### b). Pointer list
 
-There is a pointer list after the magic pattern, start at `0xB2A614` with size = `0x400`. Both wizardry c-hacks and FEBuilder Patches may find the data via such list, so that you can expand the data via FEB.
+There is a pointer list after the magic pattern, starting at `0xB2A614` with size = `0x400`. Both wizard C-hacks and FEBuilder patches can find the data via this list, so that you can expand the data via FEB.
 
 ### c). Text table
 

--- a/docs/Memory.md
+++ b/docs/Memory.md
@@ -8,17 +8,17 @@ ROM space distribution is configured in [config-memmap.h](../include/Configs/con
 | 0x0EFB2E0 | 0xE4D20 | Font
 | 0x1000000 | ---     | ***reserved for DEMO***
 
-For kernel, we mainly use free-space starting from `0xB2A604`.
+For the kernel, we mainly use free-space starting from `0xB2A604`.
 
-In order to co-work on FEBuilderGBA and make DEMO based on kernel, we need also put some inportant data at the fixed location:
+In order to collaborate with FEBuilderGBA and make DEMO based on kernel, we also need to define some important data at these fixed locations:
 
 ### a). Magic pattern
 
-[A serial of characters](../main.event#L11) is set at the head of kernel free-space (`0xB2A604`), which can make it as an identifier for [FEBuilder patch](../Patches/PATCH_SkillInfo.txt#L4).
+[A serial of characters](../main.event#L11) is set at the head of kernel free-space (`0xB2A604`), which we can use as an identifier for [FEBuilder patch](../Patches/PATCH_SkillInfo.txt#L4).
 
 ### b). Pointer list
 
-There is a pointer list after magic pattern, start at `0xB2A614` with size = `0x400`. Both wizardry c-hacks and FEBuilder Patches may find the data via such list, so that you can expand the data via FEB.
+There is a pointer list after the magic pattern, start at `0xB2A614` with size = `0x400`. Both wizardry c-hacks and FEBuilder Patches may find the data via such list, so that you can expand the data via FEB.
 
 ### c). Text table
 
@@ -32,7 +32,7 @@ TextTable is repointed at a fixed location behind the pointer list, [0xB2AA14](.
 
 ## Font space
 
-Free space at `0x0EFB2E0` is used to insert font data for further multi-languge support, which is also a reserved space.
+Free space at `0x0EFB2E0` is used to insert font data for further multi-language support, which is also a reserved space.
 
 # RAM space
 
@@ -43,10 +43,10 @@ RAM space distribution is configured in [config-memmap.s](../include/Configs/con
 | 0x02026E30 | 0x2028  | Kernel
 | 0x0203F000 | 0x1000  | ***reserved for DEMO***
 
-Since all source codes are all compiled at once, CHAX can offer a better Free-RAM-Space control method.
-Free-RAM-Space, unused memory from vanilla is collected by wizardries and now can be refered by [StanH's DOC](https://github.com/StanHash/DOC/blob/master/FREE-RAM-SPACE.md). Here we mainly use space start at `0x02026E30` with size `0x2028`, which is the debug print buffer in vanilla (and unused).
+Since the entire source code is compiled at once, CHAX can offer a better Free-RAM-Space control method.
+Free-RAM-Space (unused memory) from vanilla that has been previously identified by other wizards, can now can be referenced in [StanH's DOC](https://github.com/StanHash/DOC/blob/master/FREE-RAM-SPACE.md). Here we mainly use space starting at `0x02026E30` with size `0x2028`, which is the debug print buffer in vanilla (and unused).
 
-In kernel, free-ram space is alloced from the bottom to the top:
+In the kernel, free-RAM space is allocated from the bottom to the top:
 
 ```assembly
 0x02026E30, FreeRamSpaceTop
@@ -57,11 +57,11 @@ In kernel, free-ram space is alloced from the bottom to the top:
 0x02028E58, FreeRamSpaceBottom
 ```
 
-Developed should ensure that the free-ram space not overflowed, which means asseration `(gKernelUsedFreeRamSpaceTop > FreeRamSpaceTop)` should be valid. We have also add a detection for RAM space overflow, CHAX may auto detect on overflow error on [game-init](../Wizardry/Common/GameInitHook/source/GameInit.c#L14).
+Developers should ensure that used free-RAM space does not overflow, which means asseration `(gKernelUsedFreeRamSpaceTop > FreeRamSpaceTop)` should be valid. We have also added detection for RAM space overflows, CHAX will auto detect an overflow error on [game-init](../Wizardry/Common/GameInitHook/source/GameInit.c#L14).
 
 ## Example
 
-Here is an example to alloc ram spaces in kernel:
+Here is an example to allocate RAM space in the kernel:
 
 Suppose you want a 4 Byte RAM space (`u8 NewAlloc4Bytes[4]`)
 
@@ -72,6 +72,6 @@ Suppose you want a 4 Byte RAM space (`u8 NewAlloc4Bytes[4]`)
 _kernel_malloc NewAlloc4Bytes, 4
 ```
 > [!WARNING]
-> Make sure that the allocated space should be 32bits alligned
+> Make sure that the allocated space is 32 bits aligned
 
-3. Declare such variable in your own C file, `extern u8 NewAlloc4Bytes[4];`
+3. Declare the variable in your own C file, `extern u8 NewAlloc4Bytes[4];`

--- a/include/battle-system.h
+++ b/include/battle-system.h
@@ -72,7 +72,7 @@ extern struct {
 } gBattleTemporaryFlag;
 
 /* Battle skill act */
-bool CheckBattleSkillActivte(struct BattleUnit * actor, struct BattleUnit * target, int sid, int rate);
+bool CheckBattleSkillActivate(struct BattleUnit * actor, struct BattleUnit * target, int sid, int rate);
 
 static inline int GetItemFormSlot(struct Unit * unit, int slot)
 {


### PR DESCRIPTION
This is a chunky one. It's not comprehensive but it should go a long way.

Changes made:

- `CheckBattleSkillActivte` changed to `CheckBattleSkillActivate`
- Improved some spellings in `Memory.md` and `README.md`
- Capitalized and abbreviated mentions of DEF, RES etc for consistency in the skill descriptions, and added full stops to the end of all descriptions.