### PR TITLE
Skill - DominantArm

### DIFF
--- a/Contants/Texts/Source/texts/Skills_BattleStatus.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleStatus.txt
@@ -851,3 +851,11 @@ L-Brace[X]
 ## MSG_SKILL_LunarBrace
 Lunar Brace:[NL]
 Negate 25% of enemy defense.[X]
+
+## MSG_SKILL_DominantArm_NAME
+D-Arm[X]
+
+## MSG_SKILL_DominantArm
+Dominant Arm: If the unit's equipped[NL]
+weapon is the same type as their[NL]
+highest weapon rank, +50% weapon ATK.[X]

--- a/Data/SkillSys/SkillExtraInfo.c
+++ b/Data/SkillSys/SkillExtraInfo.c
@@ -278,6 +278,7 @@ const struct SkillExtraInfo gSkillExtraInfo[MAX_SKILL_NUM + 1] = {
     [SID_BarricadePlus] = {{ 50 }},
     [SID_Pursuer] = {{ 5, 4 }},
     [SID_GoldDigger] = {{ 100 }},
+    [SID_DominantArm] = {{ 2 }},
 
 #if (defined(SID_SealDefense) && COMMON_SKILL_VALID(SID_SealDefense))
     [SID_SealDefense] = {{ 6 }},

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -3500,4 +3500,12 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
         .icon = GFX_SkillIcon_WIP,
     },
 #endif
+
+#if (defined(SID_DominantArm) && COMMON_SKILL_VALID(SID_DominantArm))
+    [SID_DominantArm] = {
+        .name = MSG_SKILL_DominantArm_NAME,
+        .desc = MSG_SKILL_DominantArm,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
 };

--- a/Wizardry/Core/BattleSys/Source/BattleDamage.c
+++ b/Wizardry/Core/BattleSys/Source/BattleDamage.c
@@ -268,10 +268,21 @@ int BattleHit_CalcDamage(struct BattleUnit * attacker, struct BattleUnit * defen
 #if (defined(SID_TowerShieldPlus) && (COMMON_SKILL_VALID(SID_TowerShieldPlus)))
         if (BattleSkillTester(defender, SID_TowerShieldPlus))
         {
-            if(gBattleStats.range > 1)
+            if (gBattleStats.range > 1)
             {
                 RegisterTargetEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_TowerShieldPlus); 
                 return 0;
+            }
+        }
+#endif
+
+#if (defined(SID_Dazzling) && (COMMON_SKILL_VALID(SID_Dazzling)))
+        if (BattleSkillTester(defender, SID_Dazzling))
+        {
+            if (gBattleStats.range >= 3)
+            {
+            RegisterTargetEfxSkill(GetBattleHitRound(gBattleHitIterator), SID_Dazzling);
+            return 0;
             }
         }
 #endif

--- a/Wizardry/Core/BattleSys/Source/PreBattleCalc.c
+++ b/Wizardry/Core/BattleSys/Source/PreBattleCalc.c
@@ -1225,6 +1225,27 @@ void PreBattleCalcSkills(struct BattleUnit * attacker, struct BattleUnit * defen
             break;
 #endif
 
+#if (defined(SID_DominantArm) && (COMMON_SKILL_VALID(SID_DominantArm)))
+        case SID_DominantArm:
+            int weaponType = GetItemType(attacker->weapon);
+            int highestRank = 0;
+            int weaponRankType = 0;
+
+            for (int i = 0; i < 7; i++) 
+            {
+                if(attacker->unit.ranks[i] > highestRank)
+                {
+                    highestRank = attacker->unit.ranks[i];
+                    weaponRankType = i;
+                }
+            }
+
+            if (weaponType == weaponRankType)
+                attacker->battleAttack += GetItemMight(attacker->weapon) / 2;
+
+            break;
+#endif
+
         case MAX_SKILL_NUM:
         default:
             break;

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -119,6 +119,7 @@ SID_BarricadePlus
 SID_LunarBrace
 SID_Pursuer
 // SID_QuickLearner
+SID_DominantArm
 
 // Devil skills
 SID_DevilsPact


### PR DESCRIPTION
If the unit's equipped weapon belongs to the same rank as their highest weapon rank, add an additional 50% of the weapon's attack to the unit's battle attack.